### PR TITLE
Don't notify #libtom if the build was successful

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,3 @@ script:
 branches:
   only:
     - develop
-notifications:
-  irc: "chat.freenode.net#libtom"


### PR DESCRIPTION
Remove IRC notification for #libtom

... or you could also lurk around in the channel, then you can keep it like that :-P